### PR TITLE
Added compatibility with Gradle sub-modules.

### DIFF
--- a/src/main/kotlin/dsl/GodleExtension.kt
+++ b/src/main/kotlin/dsl/GodleExtension.kt
@@ -19,7 +19,7 @@ abstract class GodleExtension @Inject constructor(objectFactory: ObjectFactory, 
         objectFactory.property(GodotVersion::class.java).convention(godot(DefaultGodotVersion))
 
     //the root where the godot project lives. Defaults to the root folder.
-    val godotRoot: RegularFileProperty = objectFactory.fileProperty().convention { project.rootDir }
+    val godotRoot: RegularFileProperty = objectFactory.fileProperty().convention { project.projectDir }
 
     val godotHome: Property<String> = objectFactory.property(String::class.java).convention(
         when {

--- a/src/main/kotlin/initializers/initBaseGodot.kt
+++ b/src/main/kotlin/initializers/initBaseGodot.kt
@@ -26,36 +26,36 @@ internal fun Project.initBaseGodot() {
             }
         }
         //ignore the gradle wrapper's folder.
-        if (File(project.rootDir, "gradle/").exists()) {
-            val file = File(project.rootDir, "gradle/.gdignore")
+        if (File(project.projectDir, "gradle/").exists()) {
+            val file = File(project.projectDir, "gradle/.gdignore")
             if (!file.exists()) {
                 file.writeText("")
             }
         }
         //create runner scripts
         // Not in a task, to make it less cumbersome.
-        File(project.rootDir, "editor.sh").apply {
+        File(project.projectDir, "editor.sh").apply {
             if (!exists()) {
                 writeText(
                     "#!/bin/sh \n./gradlew godotEditor"
                 )
             }
         }
-        File(project.rootDir, "editor.bat").apply {
+        File(project.projectDir, "editor.bat").apply {
             if (!exists()) {
                 writeText(
                     "gradlew.bat godotEditor"
                 )
             }
         }
-        File(project.rootDir, "game.sh").apply {
+        File(project.projectDir, "game.sh").apply {
             if (!exists()) {
                 writeText(
                     "#!/bin/sh \n./gradlew godotRunGame"
                 )
             }
         }
-        File(project.rootDir, "game.bat").apply {
+        File(project.projectDir, "game.bat").apply {
             if (!exists()) {
                 writeText("call gradlew.bat godotRunGame")
             }


### PR DESCRIPTION
Using "project.rootDir" leads to a wrong directory if the plugin is applied only to a sub-project. Using "project.projectDir" will
deliver the intended path.