### PR TITLE
Allows the user to enable/disable the dependency between the godotRunEditor task and the build task.

### DIFF
--- a/src/main/kotlin/dsl/GodleExtension.kt
+++ b/src/main/kotlin/dsl/GodleExtension.kt
@@ -65,6 +65,13 @@ abstract class GodleExtension @Inject constructor(objectFactory: ObjectFactory, 
     //set it to true, to create a blank godot project in the godot root.
     var createBlankProject = true
 
+    /**
+     * If `true`, Godle tasks that open the Godot editor will depend on the global build task of the project. Use `false` to disable this dependency.
+     *
+     * **WARNING:** If the project doesn't build, outdated versions of bindings (e.g. `*.gdj` files) may be used by the editor.
+     */
+    var dependOnBuildTaskToOpeningEditor = true
+
     val env = HashMap<String, String>()
     fun env(key: String, value: String) {
         env[key] = value

--- a/src/main/kotlin/initializers/initBaseGodot.kt
+++ b/src/main/kotlin/initializers/initBaseGodot.kt
@@ -96,18 +96,16 @@ internal fun Project.initBaseGodot() {
             }
         }
 
-        //IF a build task exists, then we depend on it.
-        //The primary use of this is with Godot Kotlin/JVM, so the binaries are built and provided.
-        //THIS WILL BE TREATED AS A CONVENTION! IF the build task exists, then it will run!
+        // IF a build task exists, then we depend on it.
+        // The primary use of this is with Godot Kotlin/JVM, so the binaries are built and provided.
+        // THIS WILL BE TREATED AS A CONVENTION! IF the build task exists, then it will run!
         val build = tasks.findByPath("build")
 
         tasks.create("godotRunEditor", GodotExec::class.java) { exec ->
 
             with(exec) {
-                //IF a build task exists, then depend on it.
-                //The primary use of this is with Godot Kotlin/JVM, so the binaries are built and provided to godot.
-                //THIS WILL BE TREATED AS A CONVENTION! Anything running together with the build task, will be used!
-                if (build != null) {
+                // run the build command if it exists, and we are supposed to do so according to the configuration
+                if (build != null && extension.dependOnBuildTaskToOpeningEditor) {
                     this.dependsOn(build)
                 }
 


### PR DESCRIPTION
The build task may take a fair amount of time; not ideal for quickly starting the editor. If the build currently is broken (e.g. compile errors) it may prevent the user from starting the editor at all, which leads to a hunt for the executable. Let's avoid this situation.