### PR TITLE
Added support for Godot-Kotlin-JVM 0.10.0 and higher.

### DIFF
--- a/src/main/kotlin/dsl/versioning/GodotVersion.kt
+++ b/src/main/kotlin/dsl/versioning/GodotVersion.kt
@@ -30,12 +30,19 @@ data class GodotVersion(
     val majorVersion: MajorVersion = versionAsGodot3(),
     val bindingName:String = "extension_api.json",
     val headerName:String = "gdextension_interface.h",
+
+    val kotlinJvmVersion: String = "",
 ) {
     val cachedName:String = templateString(cacheName)
     fun templateString(input: String): String {
         return input
             .replace("%version%", version)
             .replace("%bit%", bit)
+            // godot-kotlin-JVM versions 0.10.0-4.3.0 and higher append
+            // the godot-kotlin-JVM version to the godot executable name (*argh*)
+            // For non-kotlin projects, this replacement will have no effect because
+            // the placeholder will not be present.
+            .replace("%kotlinJvmVersion%", this.kotlinJvmVersion)
     }
 
     fun getDownloadURL(): String {

--- a/src/main/kotlin/dsl/versioning/SemanticVersion.kt
+++ b/src/main/kotlin/dsl/versioning/SemanticVersion.kt
@@ -1,0 +1,59 @@
+package io.github.frontrider.godle.dsl.versioning
+
+data class SemanticVersion(
+    val major: Int = 0,
+    val minor: Int = 0,
+    val patch: Int = 0,
+    val suffix: String = "",
+) : Comparable<SemanticVersion> {
+
+    companion object {
+
+        val MAX = SemanticVersion(
+            major = Int.MAX_VALUE,
+            minor = Int.MAX_VALUE,
+            patch = Int.MAX_VALUE,
+        )
+
+        /**
+         * Parses a semantic version.
+         *
+         * Groups:
+         *
+         * - 0: Entire match
+         * - 1: Major (int, mandatory)
+         * - 3: Minor (int, optional)
+         * - 5: Patch (int, optional)
+         * - 6: Suffix (string, optional)
+         */
+        private val REGEX = """(\d+)(\.(\d+)(\.(\d+)(.*))?)?""".toRegex()
+
+        fun parseOrNull(string: String): SemanticVersion? {
+            val matchResult = REGEX.matchEntire(string)
+                ?: return null
+            return SemanticVersion(
+                major = matchResult.groupValues[1].toInt(),
+                minor = matchResult.groupValues[3].toIntOrNull() ?: 0,
+                patch = matchResult.groupValues[5].toIntOrNull() ?: 0,
+                suffix = matchResult.groupValues[6]
+            )
+        }
+
+    }
+
+    override fun compareTo(other: SemanticVersion): Int {
+        val majorCmp = this.major.compareTo(other.major)
+        if (majorCmp != 0) {
+            return majorCmp
+        }
+        val minorCmp = this.minor.compareTo(other.minor)
+        if (minorCmp != 0) {
+            return minorCmp
+        }
+        val patchCmp = this.patch.compareTo(other.patch)
+        if (patchCmp != 0) {
+            return patchCmp
+        }
+        return this.suffix.compareTo(other.suffix)
+    }
+}

--- a/src/main/kotlin/dsl/versioning/kotlin3.kt
+++ b/src/main/kotlin/dsl/versioning/kotlin3.kt
@@ -17,7 +17,8 @@ fun GodleExtension.`kotlin-jvm3`(version: String, detectJVM: Boolean = true): Go
         linuxBinary = "godot.x11.opt.tools.%bit%",
         windowsBinary = "godot.windows.opt.tools.%bit%.exe",
         macBinary = "godot.osx.opt.tools.%bit%",
-        isJava = true
+        isJava = true,
+        kotlinJvmVersion = version.substringBefore('-')
     )
 }
 

--- a/src/main/kotlin/dsl/versioning/kotlin4.kt
+++ b/src/main/kotlin/dsl/versioning/kotlin4.kt
@@ -4,8 +4,78 @@ package io.github.frontrider.godle.dsl.versioning
 
 import io.github.frontrider.godle.dsl.GodleExtension
 
+
+private val KOTLIN_JVM_MODULE_VERSIONS_TO_DETAILS =
+    mapOf(
+        // versions 0.10.0 and up all share the same schema
+        SemanticVersion(0, 10, 0)..SemanticVersion.MAX to GodotVersionDetails(
+            linuxDownloadURL = "https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/%version%/godot-kotlin-jvm_editor_linuxbsd_x86_64_release_%version%.zip",
+            windowsDownloadURL = "https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/%version%/godot-kotlin-jvm_editor_windows_x86_64_release_%version%.zip",
+            macDownloadURL = "https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/%version%/godot-kotlin-jvm_editor_macos_universal_release_%version%.zip",
+            linuxBinary = "godot.linuxbsd.editor.x86_%bit%.jvm.%kotlinJvmVersion%",
+            windowsBinary = "godot.windows.editor.x86_%bit%.jvm.%kotlinJvmVersion%.exe",
+            macBinary = "Godot",
+        ),
+
+        // versions 0.9.1 - 0.7.0 have a different pattern than newer versions
+        SemanticVersion(0, 9, 1)..SemanticVersion(0, 7, 0) to GodotVersionDetails(
+            linuxDownloadURL = "https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/%version%/godot-kotlin-jvm_editor_x11_%version%.zip",
+            windowsDownloadURL = "https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/%version%/godot-kotlin-jvm_editor_windows_%version%.zip",
+            macDownloadURL = "https://github.com/utopia-rise/godot-kotlin-jvm/releases/download/%version%/godot-kotlin-jvm_editor_osx_%version%.zip",
+            linuxBinary = "godot.linuxbsd.editor.x86_%bit%",
+            windowsBinary = "godot.windows.editor.x86_%bit%.exe",
+            macBinary = "Godot",
+        )
+
+        // versions below 0.7.0 are not compatible with Godot 4.x.
+    )
+
+
+
+
 //kotlin/jvm support
 fun GodleExtension.`kotlin-jvm4`(version: String, detectJVM: Boolean = true): GodotVersion {
+    if (version.contains('-')) {
+        // split the version of the godot engine and the godot-kotlin-jvm module
+        // example input: 0.11.0-4.3
+        val kotlinJvmModuleVersion = version.substringBefore('-')
+        val semanticVersion = SemanticVersion.parseOrNull(kotlinJvmModuleVersion)
+        if(semanticVersion == null){
+            project.logger.debug("Could not parse semantic Godot-Kotlin-JVM module version from string '${kotlinJvmModuleVersion}'. Falling back to the defaults.")
+            return createDefaultGodotVersion(version)
+        }
+
+        val details = KOTLIN_JVM_MODULE_VERSIONS_TO_DETAILS.asSequence().filter { semanticVersion in it.key }.maxByOrNull { it.key.start }?.value
+        if(details == null){
+            project.logger.debug("Could not determine a concrete version details for Godot-Kotlin-VM version '${kotlinJvmModuleVersion}'. Falling back to the defaults.")
+            return createDefaultGodotVersion(version)
+        }
+
+        // we've determined the pattern for the download URLs for the given version.
+        return createGodotVersionFromDetails(version, details)
+    }
+
+    // we could not parse the godot version into a semantic version for further differentiation
+    // -> use the default format.
+    return createDefaultGodotVersion(version)
+}
+
+private fun createGodotVersionFromDetails(version: String, details: GodotVersionDetails): GodotVersion {
+    return GodotVersion(
+        version = version,
+        cacheName = "v%version%-%bit%-kotlin",
+        linuxDownloadURL = details.linuxDownloadURL,
+        windowsDownloadURL = details.windowsDownloadURL,
+        macDownloadURL = details.macDownloadURL,
+        linuxBinary = details.linuxBinary,
+        windowsBinary = details.windowsBinary,
+        macBinary = details.macBinary,
+        isJava = true,
+        kotlinJvmVersion = version.substringBefore('-')
+    )
+}
+
+private fun createDefaultGodotVersion(version: String): GodotVersion {
     return GodotVersion(
         version = version,
         cacheName = "v%version%-%bit%-kotlin",
@@ -15,9 +85,19 @@ fun GodleExtension.`kotlin-jvm4`(version: String, detectJVM: Boolean = true): Go
         linuxBinary = "godot.linuxbsd.editor.x86_%bit%",
         windowsBinary = "godot.windows.editor.x86_%bit%.exe",
         macBinary = "Godot",
-        isJava = true
+        isJava = true,
+        kotlinJvmVersion = version.substringBefore('-')
     )
 }
+
+private data class GodotVersionDetails(
+    val linuxDownloadURL: String,
+    val windowsDownloadURL: String,
+    val macDownloadURL: String,
+    val linuxBinary: String,
+    val windowsBinary: String,
+    val macBinary: String,
+)
 
 /**
  * This variant exists for groovy.


### PR DESCRIPTION
These versions use a different schema for
the download URLs as well as for the extracted
godot executable (Windows and Linux only).

Support for versions before 0.10.0 has been
retained.